### PR TITLE
Updated the auth flow so the weak Remember me toggle is gone

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -2,14 +2,13 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { App, Button, Checkbox, Form, Input, Typography } from "antd";
+import { App, Button, Form, Input, Typography } from "antd";
 import { useAuthActions } from "@/providers/authProvider";
 import { useStyles } from "./styles";
 
 export interface LoginFormValues {
   email: string;
   password: string;
-  rememberMe?: boolean;
 }
 
 const { Text } = Typography;
@@ -27,7 +26,6 @@ export function LoginForm() {
       await signIn({
         userNameOrEmailAddress: values.email,
         password: values.password,
-        rememberClient: values.rememberMe ?? false,
       });
       message.success("Signed in successfully.");
     } catch (error) {
@@ -80,14 +78,6 @@ export function LoginForm() {
         </Form.Item>
 
         <div className={styles.helperRow}>
-          <Form.Item<LoginFormValues>
-            name="rememberMe"
-            valuePropName="checked"
-            noStyle
-          >
-            <Checkbox>Remember me</Checkbox>
-          </Form.Item>
-
           <Button type="link" style={{ paddingInline: 0 }}>
             Forgot password?
           </Button>

--- a/frontend/src/providers/authProvider/context.tsx
+++ b/frontend/src/providers/authProvider/context.tsx
@@ -39,7 +39,6 @@ export interface ICurrentLoginInformations {
 export interface ISignInInput {
     userNameOrEmailAddress: string;
     password: string;
-    rememberClient: boolean;
 }
 
 export interface ISignUpInput {

--- a/frontend/src/providers/authProvider/index.tsx
+++ b/frontend/src/providers/authProvider/index.tsx
@@ -126,7 +126,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
                 {
                     userNameOrEmailAddress: input.userNameOrEmailAddress,
                     password: input.password,
-                    rememberClient: input.rememberClient
+                    rememberClient: true
                 },
                 {
                     headers: {
@@ -139,7 +139,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
                 response.data,
                 "We could not sign you in."
             );
-            setAuthCookie(auth.accessToken, auth.expireInSeconds, input.rememberClient);
+            setAuthCookie(auth.accessToken, auth.expireInSeconds, true);
             const currentLoginInformations = await fetchCurrentUser(auth);
 
             dispatch(
@@ -191,8 +191,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
             if (registerResult.canLogin) {
                 await signIn({
                     userNameOrEmailAddress: input.emailAddress,
-                    password: input.password,
-                    rememberClient: true
+                    password: input.password
                 });
             }
         } catch (error) {
@@ -214,7 +213,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
         try {
             await fetchCurrentUser();
-            dispatch(bootstrapAuthSuccess());
         } catch {
             removeAuthCookie();
             removeTenantContext();
@@ -290,7 +288,7 @@ function toError(error: unknown, fallbackMessage: string): Error {
         "data" in error.response
     ) {
         const data = error.response.data as IAbpAjaxResponse<unknown>;
-        const message = data?.error?.message ?? fallbackMessage;
+        const message = data?.error?.details ?? data?.error?.message ?? fallbackMessage;
         return new Error(message);
     }
 


### PR DESCRIPTION
also improved failed-login messaging by preferring backend error.details over the top-level message, so invalid credentials should now show something useful like Invalid user name or password instead of the ugly [[Login Failed]]